### PR TITLE
feat: add presigned URL for Google Cloud Storage

### DIFF
--- a/app/handler/file.go
+++ b/app/handler/file.go
@@ -157,6 +157,27 @@ func (f *FileHandler) CreateBucket(ctx *gin.Context) {
 	helper.ResponseAPI(ctx, response)
 }
 
+func (f *FileHandler) PresignedURL(ctx *gin.Context) {
+	apiCallID := ctx.GetString(constant.RequestIDKey)
+
+	var req request.PresignedURLRequest
+	if err := ctx.ShouldBindQuery(&req); err != nil {
+		helper.LogError(apiCallID, "Failed to bind request: "+err.Error())
+		helper.ResponseAPI(ctx, constant.Res400InvalidPayload)
+		return
+	}
+
+	if err := f.Validator.Struct(req); err != nil {
+		helper.LogError(apiCallID, "Payload validation failed: "+err.Error())
+		formattedErrors := helper.ErrorValidationFormatter(err.(validator.ValidationErrors))
+		helper.ResponseAPI(ctx, constant.Res400InvalidPayload, formattedErrors)
+		return
+	}
+
+	result, response := f.Service.GeneratePresignedURL(apiCallID, req.Path, req.Expires)
+	helper.ResponseAPI(ctx, response, result)
+}
+
 func (f *FileHandler) DeleteFile(ctx *gin.Context) {
 	apiCallID := ctx.GetString(constant.RequestIDKey)
 

--- a/app/integration/gcs.go
+++ b/app/integration/gcs.go
@@ -3,11 +3,13 @@ package integration
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"github.com/spf13/viper"
 	"google.golang.org/api/iterator"
 	"io"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -178,6 +180,71 @@ func (g *GCS) CreateBucket(apiCallID, bucketName string) error {
 		return fmt.Errorf("Bucket(%q).Create: %w", bucketName, err)
 	}
 	return nil
+}
+
+// serviceAccountKey represents the minimal fields needed from a GCP service account JSON key file.
+type serviceAccountKey struct {
+	ClientEmail string `json:"client_email"`
+	PrivateKey  string `json:"private_key"`
+}
+
+// loadServiceAccountKey reads and parses a GCP service account JSON key file,
+// returning the client_email and private_key needed for URL signing.
+func loadServiceAccountKey(filePath string) (*serviceAccountKey, error) {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read service account key file: %w", err)
+	}
+
+	var key serviceAccountKey
+	if err := json.Unmarshal(data, &key); err != nil {
+		return nil, fmt.Errorf("failed to parse service account key JSON: %w", err)
+	}
+
+	if key.ClientEmail == "" || key.PrivateKey == "" {
+		return nil, fmt.Errorf("service account key file missing client_email or private_key")
+	}
+
+	return &key, nil
+}
+
+// GeneratePresignedURL generates a presigned (temporary) URL for downloading an object
+// from GCS without requiring the caller to have GCP credentials.
+// The URL is valid for the specified expiration duration.
+func (g *GCS) GeneratePresignedURL(apiCallID, objectPath string, expiration time.Duration) (string, error) {
+	helper.LogInfo(apiCallID, "Generating presigned URL for: "+objectPath)
+
+	ctx := context.Background()
+	client, err := g.initClient(ctx, apiCallID, g.ConfigSA)
+	if err != nil {
+		return "", fmt.Errorf("storage.NewClient: %w", err)
+	}
+	defer client.Close()
+
+	opts := &storage.SignedURLOptions{
+		Scheme:  storage.SigningSchemeV4,
+		Method:  "GET",
+		Expires: time.Now().Add(expiration),
+	}
+
+	// When using a local service account key file, provide explicit signing credentials.
+	// Otherwise, rely on the client's automatic credential detection (ADC with SignBytes support).
+	if g.ConfigSA {
+		saKey, err := loadServiceAccountKey(g.CredentialFilePath)
+		if err != nil {
+			return "", fmt.Errorf("failed to load service account key for signing: %w", err)
+		}
+		opts.GoogleAccessID = saKey.ClientEmail
+		opts.PrivateKey = []byte(saKey.PrivateKey)
+	}
+
+	url, err := client.Bucket(g.BucketName).SignedURL(objectPath, opts)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate signed URL: %w", err)
+	}
+
+	helper.LogInfo(apiCallID, "Presigned URL generated successfully for: "+objectPath)
+	return url, nil
 }
 
 func (g *GCS) DeleteFile(apiCallID, path string) error {

--- a/app/resource/request/file.go
+++ b/app/resource/request/file.go
@@ -18,3 +18,8 @@ type CreateBucketRequest struct {
 type DeleteFileRequest struct {
 	Path string `validate:"required,not_only_space"`
 }
+
+type PresignedURLRequest struct {
+	Path    string `form:"path" validate:"required,not_only_space"`
+	Expires int    `form:"expires" validate:"omitempty,min=1,max=10080"`
+}

--- a/app/resource/response/file.go
+++ b/app/resource/response/file.go
@@ -20,6 +20,12 @@ type GetFileResponse struct {
 	UpdatedAt string `json:"updatedAt"`
 }
 
+type PresignedURLResponse struct {
+	URL       string `json:"url"`
+	Path      string `json:"path"`
+	ExpiresAt string `json:"expires_at"`
+}
+
 func GetFileResponseFormatter(listFile *[]storage.ObjectAttrs) []GetFileResponse {
 	var result []GetFileResponse
 

--- a/app/router/global.go
+++ b/app/router/global.go
@@ -11,4 +11,5 @@ func initGlobalRoutes(config *Config) {
 	globalApiFile.GET("/list", config.FileHandler.GetAllFile)
 	globalApiFile.GET("/list/:folder", config.FileHandler.GetSpecificFile)
 	globalApiFile.DELETE("/delete", config.FileHandler.DeleteFile)
+	globalApiFile.GET("/presigned-url", config.FileHandler.PresignedURL)
 }

--- a/app/service/file.go
+++ b/app/service/file.go
@@ -8,6 +8,7 @@ import (
 	"go-google-cloud-storage/app/helper"
 	"go-google-cloud-storage/app/integration"
 	"go-google-cloud-storage/app/resource/response"
+	"time"
 )
 
 type FileService struct {
@@ -104,6 +105,34 @@ func (f *FileService) CreateBucket(apiCallID, bucketName string) constant.Respon
 	}
 
 	return constant.Res200Save
+}
+
+func (f *FileService) GeneratePresignedURL(apiCallID, filePath string, expiresInMinutes int) (*response.PresignedURLResponse, constant.ResponseMap) {
+	gcs, err := integration.GCSInstance(f.Viper)
+	if err != nil {
+		helper.LogError(apiCallID, "Error creating GCS configuration: "+err.Error())
+		return nil, constant.Res422SomethingWentWrong
+	}
+
+	// Default expiration to 15 minutes if not specified or invalid
+	if expiresInMinutes <= 0 {
+		expiresInMinutes = 15
+	}
+
+	expiration := time.Duration(expiresInMinutes) * time.Minute
+	expiresAt := time.Now().UTC().Add(expiration)
+
+	url, err := gcs.GeneratePresignedURL(apiCallID, filePath, expiration)
+	if err != nil {
+		helper.LogError(apiCallID, "Error generating presigned URL: "+err.Error())
+		return nil, constant.Res422SomethingWentWrong
+	}
+
+	return &response.PresignedURLResponse{
+		URL:       url,
+		Path:      filePath,
+		ExpiresAt: expiresAt.Format(time.RFC3339),
+	}, constant.Res200Get
 }
 
 func (f *FileService) DeleteFile(apiCallID, path string) constant.ResponseMap {

--- a/test/handler/file_test.go
+++ b/test/handler/file_test.go
@@ -1,0 +1,168 @@
+package handler_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/spf13/viper"
+	"go-google-cloud-storage/app/config"
+	"go-google-cloud-storage/app/constant"
+	"go-google-cloud-storage/app/handler"
+	"go-google-cloud-storage/app/helper"
+	"go-google-cloud-storage/app/middleware"
+	"go-google-cloud-storage/app/service"
+)
+
+// setupTestRouter creates a Gin engine with all routes registered
+func setupTestRouter() *gin.Engine {
+	gin.SetMode(gin.TestMode)
+
+	server := gin.New()
+	server.Use(middleware.RequestID())
+
+	// Setup Viper — leave GCS values empty so we test validation behavior
+	v := viper.New()
+	v.Set("APP_PORT", 4001)
+
+	validator := config.NewValidator()
+	fileService := service.NewFileService(v)
+	fileHandler := handler.NewFileHandler(fileService, validator)
+
+	api := server.Group("/api/v1")
+	api.GET("/list", fileHandler.GetAllFile)
+	api.POST("/upload", fileHandler.UploadFile)
+	api.GET("/download", fileHandler.DownloadFile)
+	api.POST("/bucket/create", fileHandler.CreateBucket)
+	api.DELETE("/delete", fileHandler.DeleteFile)
+	api.GET("/presigned-url", fileHandler.PresignedURL)
+
+	return server
+}
+
+func TestPresignedURL_InvalidRequest(t *testing.T) {
+	router := setupTestRouter()
+
+	tests := []struct {
+		name  string
+		query string
+	}{
+		{
+			name:  "missing path parameter",
+			query: "",
+		},
+		{
+			name:  "empty path value",
+			query: "path=",
+		},
+		{
+			name:  "valid params but no GCS config",
+			query: "path=test.jpg&expires=15",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, _ := http.NewRequest(http.MethodGet, "/api/v1/presigned-url?"+tt.query, nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			// Accept 400 (validation error) or 422 (GCS config missing)
+			if w.Code != http.StatusBadRequest && w.Code != http.StatusUnprocessableEntity {
+				t.Errorf("Expected 400 or 422, got %d: %s", w.Code, w.Body.String())
+			}
+
+			var response helper.Response
+			json.Unmarshal(w.Body.Bytes(), &response)
+			if response.ApiID == "" {
+				t.Error("Response missing api_id")
+			}
+		})
+	}
+}
+
+func TestPresignedURL_InvalidExpires(t *testing.T) {
+	router := setupTestRouter()
+
+	tests := []struct {
+		name  string
+		query string
+	}{
+		{
+			name:  "zero expires",
+			query: "path=test.jpg&expires=0",
+		},
+		{
+			name:  "negative expires",
+			query: "path=test.jpg&expires=-1",
+		},
+		{
+			name:  "expires exceeds max (10080 minutes = 7 days)",
+			query: "path=test.jpg&expires=10081",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, _ := http.NewRequest(http.MethodGet, "/api/v1/presigned-url?"+tt.query, nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			// These should fail validation → 400, or fail on GCS config → 422
+			if w.Code != http.StatusBadRequest && w.Code != http.StatusUnprocessableEntity {
+				t.Errorf("Expected 400 or 422, got %d: %s", w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
+func TestRoutes_ResponseFormat(t *testing.T) {
+	router := setupTestRouter()
+
+	endpoints := []struct {
+		method string
+		path   string
+		body   string
+	}{
+		{http.MethodGet, "/api/v1/list", ""},
+		{http.MethodGet, "/api/v1/presigned-url?path=test.jpg&expires=15", ""},
+		{http.MethodGet, "/api/v1/download", ""},
+		{http.MethodDelete, "/api/v1/delete", `{"path":"test.jpg"}`},
+	}
+
+	for _, ep := range endpoints {
+		t.Run(ep.method+"_"+ep.path, func(t *testing.T) {
+			var req *http.Request
+			if ep.body != "" {
+				req, _ = http.NewRequest(ep.method, ep.path, nil)
+				req.Header.Set("Content-Type", "application/json")
+				// For DELETE with body, we need to pass the body differently
+				bodyReader := strings.NewReader(ep.body)
+				req, _ = http.NewRequest(ep.method, ep.path, bodyReader)
+				req.Header.Set("Content-Type", "application/json")
+			} else {
+				req, _ = http.NewRequest(ep.method, ep.path, nil)
+			}
+
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			var response helper.Response
+			if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+				t.Errorf("Response is not valid JSON: %s", w.Body.String())
+				return
+			}
+
+			if response.ApiID == "" {
+				t.Errorf("Response missing api_id field for %s %s", ep.method, ep.path)
+			}
+			if response.Status != constant.ResponseStatusSuccess &&
+				response.Status != constant.ResponseStatusFailed {
+				t.Errorf("Invalid status %q for %s %s", response.Status, ep.method, ep.path)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Add presigned URL functionality to GCS, mirroring the existing implementation in the AWS S3 project.

## Changes

- **Integration layer** (): Add `GeneratePresignedURL` using `storage.BucketHandle.SignedURL()` with SigningSchemeV4. Supports both service account JSON key-based signing and ADC.
- **Service layer** (): Business logic with default 15-minute expiration
- **Handler** (): `GET /api/v1/presigned-url?path=&expires=` with validation
- **Request DTO**: `PresignedURLRequest` — path (required), expires (optional, min=1, max=10080 minutes)
- **Response DTO**: `PresignedURLResponse` — url, path, expires_at
- **Tests** (): Validation tests for missing path, empty path, invalid expires, and response format

## How to use

```bash
# Default 15 minutes
curl "http://localhost:4000/api/v1/presigned-url?path=images/photo.jpg"

# Custom expiration (60 minutes)
curl "http://localhost:4000/api/v1/presigned-url?path=images/photo.jpg&expires=60"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)